### PR TITLE
Parallel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ extensions = [
     Extension("metawards._extract_data_for_graphics", ["src/metawards/_extract_data_for_graphics.pyx"]),
     Extension("metawards._import_infection", ["src/metawards/_import_infection.pyx"]+random_sources),
     Extension("metawards._ran_binomial", ["src/metawards/_ran_binomial.pyx"]+random_sources),
+    Extension("metawards._assert_sane_network", ["src/metawards/_assert_sane_network.pyx"]),
     Extension("metawards._parallel", ["src/metawards/_parallel.pyx"]),
 ]
 

--- a/src/metawards/_assert_sane_network.pyx
+++ b/src/metawards/_assert_sane_network.pyx
@@ -1,0 +1,50 @@
+#!/bin/env python3
+#cython: boundscheck=False
+#cython: cdivision=True
+#cython: initializedcheck=False
+#cython: cdivision_warnings=False
+#cython: wraparound=False
+#cython: binding=False
+#cython: initializedcheck=False
+#cython: nonecheck=False
+#cython: overflowcheck=False
+
+from ._network import Network
+
+__all__ = ["assert_sane_network"]
+
+
+cdef int * get_int_array_ptr(int_array):
+    """Return the raw C pointer to the passed int array which was
+       created using create_int_array
+    """
+    cdef int [::1] a = int_array
+    return &(a[0])
+
+
+def assert_sane_network(network: Network):
+    """This function runs through and checks that the passed network
+       is sane. If it is not, it prints some information and raises
+       an AssertionError
+    """
+    # first check that the ith link really corresponds to the ith node.
+    # This is assumed in most of the code
+    """cdef int nlinks = network.nlinks
+    cdef int nplay = network.plinks
+    cdef int nnodes = network.nnodes
+
+    assert nnodes <= nlinks
+
+    links = network.to_links
+    nodes = network.nodes
+    plinks = network.play
+
+    cdef int * links_ifrom = get_int_array_ptr(links.ifrom)
+    cdef int * links_ito = get_int_array_ptr(links.ito)
+    cdef int * nodes_label = get_int_array_ptr(nodes.label)
+
+    cdef int i"""
+    pass
+
+    # Will add sanity checks as I get to fully understand this
+    # data layout...

--- a/src/metawards/_extract_data.pyx
+++ b/src/metawards/_extract_data.pyx
@@ -124,16 +124,16 @@ cdef void reset_reduce_variables(red_variables * variables,
     cdef int n = nthreads
 
     for i in range(0, n):
-        variables.sum_x = 0
-        variables.sum_y = 0
-        variables.sum_x2 = 0
-        variables.sum_y2 = 0
-        variables.n_inf_wards = 0
-        variables.total_new = 0
-        variables.inf_tot = 0
-        variables.pinf_tot = 0
-        variables.is_dangerous = 0
-        variables.susceptibles = 0
+        variables[i].sum_x = 0
+        variables[i].sum_y = 0
+        variables[i].sum_x2 = 0
+        variables[i].sum_y2 = 0
+        variables[i].n_inf_wards = 0
+        variables[i].total_new = 0
+        variables[i].inf_tot = 0
+        variables[i].pinf_tot = 0
+        variables[i].is_dangerous = 0
+        variables[i].susceptibles = 0
 
 
 cdef red_variables* allocate_red_variables(int nthreads) nogil:

--- a/src/metawards/_extract_data.pyx
+++ b/src/metawards/_extract_data.pyx
@@ -69,6 +69,14 @@ cdef void free_inf_buffers(inf_buffer *buffers, int nthreads) nogil:
     free(buffers)
 
 
+cdef void reset_inf_buffer(inf_buffer *buffers, int nthreads) nogil:
+    cdef int n = nthreads
+    cdef int i = 0
+
+    for i in range(0, n):
+        buffers[i].count = 0
+
+
 cdef void add_from_buffer(inf_buffer *buffer, int *wards_infected) nogil:
     cdef int i = 0
     cdef int count = buffer[0].count
@@ -307,6 +315,11 @@ def extract_data(network: Network, infections, play_infections,
         inf_tot[i] = 0
         pinf_tot[i] = 0
         reset_reduce_variables(redvars, num_threads)
+        reset_inf_buffer(total_inf_ward_buffers, num_threads)
+        reset_inf_buffer(total_new_inf_ward_buffers, num_threads)
+        if cSELFISOLATE:
+            reset_inf_buffer(is_dangerous_buffers, num_threads)
+
         infections_i = get_int_array_ptr(infections[i])
         play_infections_i = get_int_array_ptr(play_infections[i])
 

--- a/src/metawards/_initialise_infections.py
+++ b/src/metawards/_initialise_infections.py
@@ -1,7 +1,7 @@
 
-from array import array
 
 from ._network import Network
+from ._array import create_int_array
 
 __all__ = ["initialise_infections",
            "initialise_play_infections"]
@@ -21,13 +21,11 @@ def initialise_infections(network: Network):
 
     infections = []
 
-    nlinks = network.nlinks + 1
-
-    int_t = "i"
-    null_int = nlinks * [0]
-
+    # 'infections' holds all of the infections recorded for every
+    # single link in network.to_links. 1-indexing is used throughout
+    # the code, hence why we size for n + 1
     for _ in range(0, n):
-        infections.append( array(int_t, null_int) )
+        infections.append(create_int_array(network.nlinks + 1))
 
     return infections
 
@@ -46,12 +44,10 @@ def initialise_play_infections(network: Network):
 
     infections = []
 
-    nnodes = network.nnodes + 1
-
-    int_t = "i"
-    null_int = nnodes * [0]
-
+    # the 'play_infections' holds the infections that occur in
+    # each ward (node) according to the 'play' rules. 1-indexing
+    # is used throughout the code, hence why we size for n + 1
     for _ in range(0, n):
-        infections.append( array(int_t, null_int) )
+        infections.append(create_int_array(network.nnodes+1))
 
     return infections

--- a/src/metawards/_iterate.pyx
+++ b/src/metawards/_iterate.pyx
@@ -30,6 +30,22 @@ from ._ran_binomial cimport _ran_binomial, _get_binomial_ptr, binomial_rng
 __all__ = ["iterate"]
 
 
+cdef double * get_double_array_ptr(double_array):
+    """Return the raw C pointer to the passed double array which was
+       created using create_double_array
+    """
+    cdef double [::1] a = double_array
+    return &(a[0])
+
+
+cdef int * get_int_array_ptr(int_array):
+    """Return the raw C pointer to the passed int array which was
+       created using create_int_array
+    """
+    cdef int [::1] a = int_array
+    return &(a[0])
+
+
 cdef struct foi_buffer:
     int count
     int *index
@@ -84,16 +100,6 @@ cdef inline void add_to_buffer(foi_buffer *buffer, int index, double value,
         buffer[0].count = 0
 
 
-cdef double * _get_double_array_ptr(double_array):
-    cdef double [::1] a = double_array
-    return &(a[0])
-
-
-cdef int * _get_int_array_ptr(int_array):
-    cdef int [::1] a = int_array
-    return &(a[0])
-
-
 def iterate(network: Network, infections, play_infections,
             params: Parameters, rngs, timestep: int,
             population: int, nthreads: int = None,
@@ -132,8 +138,8 @@ def iterate(network: Network, infections, play_infections,
     plinks = network.play
 
     cdef int i = 0
-    cdef double * wards_day_foi = _get_double_array_ptr(wards.day_foi)
-    cdef double * wards_night_foi = _get_double_array_ptr(wards.night_foi)
+    cdef double * wards_day_foi = get_double_array_ptr(wards.day_foi)
+    cdef double * wards_night_foi = get_double_array_ptr(wards.night_foi)
     cdef double night_foi
 
     p = p.start("setup")
@@ -170,35 +176,35 @@ def iterate(network: Network, infections, play_infections,
     cdef int inf_ij = 0
     cdef double weight = 0.0
     cdef double distance = 0.0
-    cdef double * links_weight = _get_double_array_ptr(links.weight)
-    cdef int * links_ifrom = _get_int_array_ptr(links.ifrom)
-    cdef int * links_ito = _get_int_array_ptr(links.ito)
+    cdef double * links_weight = get_double_array_ptr(links.weight)
+    cdef int * links_ifrom = get_int_array_ptr(links.ifrom)
+    cdef int * links_ito = get_int_array_ptr(links.ito)
     cdef int ifrom = 0
     cdef int ito = 0
     cdef int staying, moving, play_move, end_p
-    cdef double * links_distance = _get_double_array_ptr(links.distance)
+    cdef double * links_distance = get_double_array_ptr(links.distance)
     cdef double frac = 0.0
     cdef double cumulative_prob = 0
     cdef double prob_scaled
     cdef double too_ill_to_move
 
-    cdef int * wards_begin_p = _get_int_array_ptr(wards.begin_p)
-    cdef int * wards_end_p = _get_int_array_ptr(wards.end_p)
+    cdef int * wards_begin_p = get_int_array_ptr(wards.begin_p)
+    cdef int * wards_end_p = get_int_array_ptr(wards.end_p)
 
-    cdef double * plinks_distance = _get_double_array_ptr(plinks.distance)
-    cdef double * plinks_weight = _get_double_array_ptr(plinks.weight)
-    cdef int * plinks_ifrom = _get_int_array_ptr(plinks.ifrom)
-    cdef int * plinks_ito = _get_int_array_ptr(plinks.ito)
+    cdef double * plinks_distance = get_double_array_ptr(plinks.distance)
+    cdef double * plinks_weight = get_double_array_ptr(plinks.weight)
+    cdef int * plinks_ifrom = get_int_array_ptr(plinks.ifrom)
+    cdef int * plinks_ito = get_int_array_ptr(plinks.ito)
 
-    cdef double * wards_denominator_d = _get_double_array_ptr(wards.denominator_d)
-    cdef double * wards_denominator_n = _get_double_array_ptr(wards.denominator_n)
-    cdef double * wards_denominator_p = _get_double_array_ptr(wards.denominator_p)
-    cdef double * wards_denominator_pd = _get_double_array_ptr(wards.denominator_pd)
+    cdef double * wards_denominator_d = get_double_array_ptr(wards.denominator_d)
+    cdef double * wards_denominator_n = get_double_array_ptr(wards.denominator_n)
+    cdef double * wards_denominator_p = get_double_array_ptr(wards.denominator_p)
+    cdef double * wards_denominator_pd = get_double_array_ptr(wards.denominator_pd)
 
-    cdef double * links_suscept = _get_double_array_ptr(links.suscept)
-    cdef double * wards_play_suscept = _get_double_array_ptr(wards.play_suscept)
+    cdef double * links_suscept = get_double_array_ptr(links.suscept)
+    cdef double * wards_play_suscept = get_double_array_ptr(wards.play_suscept)
 
-    cdef int * wards_label = _get_int_array_ptr(wards.label)
+    cdef int * wards_label = get_int_array_ptr(wards.label)
 
     cdef int * infections_i
     cdef int * play_infections_i
@@ -220,7 +226,7 @@ def iterate(network: Network, infections, play_infections,
 
     if SELFISOLATE:
         cSELFISOLATE = 1
-        is_dangerous_array = _get_int_array_ptr(is_dangerous)
+        is_dangerous_array = get_int_array_ptr(is_dangerous)
 
     cdef openmp.omp_lock_t lock
     openmp.omp_init_lock(&lock)
@@ -237,8 +243,8 @@ def iterate(network: Network, infections, play_infections,
         play_at_home_scl = <double>(params.dyn_play_at_home *
                                     too_ill_to_move)
 
-        infections_i = _get_int_array_ptr(infections[i])
-        play_infections_i = _get_int_array_ptr(play_infections[i])
+        infections_i = get_int_array_ptr(infections[i])
+        play_infections_i = get_int_array_ptr(play_infections[i])
 
         if contrib_foi > 0:
             p = p.start(f"work_{i}")
@@ -420,10 +426,10 @@ def iterate(network: Network, infections, play_infections,
     p = p.start("recovery")
     for i in range(N_INF_CLASSES-2, -1, -1):
         # recovery, move through classes backwards (loop down to 0)
-        infections_i = _get_int_array_ptr(infections[i])
-        infections_i_plus_one = _get_int_array_ptr(infections[i+1])
-        play_infections_i = _get_int_array_ptr(play_infections[i])
-        play_infections_i_plus_one = _get_int_array_ptr(play_infections[i+1])
+        infections_i = get_int_array_ptr(infections[i])
+        infections_i_plus_one = get_int_array_ptr(infections[i+1])
+        play_infections_i = get_int_array_ptr(play_infections[i])
+        play_infections_i_plus_one = get_int_array_ptr(play_infections[i+1])
         disease_progress = params.disease_params.progress[i]
 
         with nogil, parallel(num_threads=num_threads):
@@ -459,8 +465,8 @@ def iterate(network: Network, infections, play_infections,
 
     # i is set to 0 now as we are only dealing now with new infections
     i = 0
-    infections_i = _get_int_array_ptr(infections[i])
-    play_infections_i = _get_int_array_ptr(play_infections[i])
+    infections_i = get_int_array_ptr(infections[i])
+    play_infections_i = get_int_array_ptr(play_infections[i])
 
     p = p.start("fixed")
     with nogil, parallel(num_threads=num_threads):

--- a/src/metawards/_iterate.pyx
+++ b/src/metawards/_iterate.pyx
@@ -52,7 +52,7 @@ cdef struct foi_buffer:
     double *foi
 
 
-cdef foi_buffer* allocate_foi_buffers(int nthreads, int buffer_size=1024) nogil:
+cdef foi_buffer* allocate_foi_buffers(int nthreads, int buffer_size=4096) nogil:
     cdef int size = buffer_size
     cdef int n = nthreads
 
@@ -86,14 +86,15 @@ cdef void add_from_buffer(foi_buffer *buffer, double *wards_foi) nogil:
 
 cdef inline void add_to_buffer(foi_buffer *buffer, int index, double value,
                                double *wards_foi,
-                               openmp.omp_lock_t *lock) nogil:
+                               openmp.omp_lock_t *lock,
+                               int buffer_size=4096) nogil:
     cdef int count = buffer[0].count
 
     buffer[0].index[count] = index
     buffer[0].foi[count] = value
     buffer[0].count = count + 1
 
-    if buffer[0].count >= 1024:
+    if buffer[0].count >= buffer_size:
         openmp.omp_set_lock(lock)
         add_from_buffer(buffer, wards_foi)
         openmp.omp_unset_lock(lock)

--- a/src/metawards/_network.py
+++ b/src/metawards/_network.py
@@ -90,6 +90,10 @@ class Network:
                                  max_links=max_links)
         p = p.stop()
 
+        # sanity-check that the network makes sense - there are specific
+        # requirements for the data layout
+        network.assert_sane()
+
         if calculate_distances:
             p = p.start("add_distances")
             network.add_distances(distance_function=distance_function)
@@ -129,6 +133,15 @@ class Network:
             print(p)
 
         return network
+
+    def assert_sane(self):
+        """Assert that this network is sane. This checks that the network
+           is laid out correctly in memory and that it doesn't have
+           anything unexpected. Checking here will prevent us from having
+           to check every time the network is accessed
+        """
+        from ._utils import assert_sane_network
+        assert_sane_network(self)
 
     def add_distances(self, distance_function=None):
         """Read in the positions of all of the nodes (wards) and calculate

--- a/src/metawards/_nodes.pyx
+++ b/src/metawards/_nodes.pyx
@@ -51,6 +51,9 @@ class Nodes:
             self.denominator_p = create_double_array(N, 0.0)
             self.denominator_pd = create_double_array(N, 0.0)
 
+            self.day_inf_prob = create_double_array(N, 0.0)
+            self.night_inf_prob = create_double_array(N, 0.0)
+
             self.x = create_double_array(N, 0.0)  # no good initialiser for x
             self.y = create_double_array(N, 0.0)  # no good initialiser for y
 

--- a/src/metawards/_rate_to_prob.pxd
+++ b/src/metawards/_rate_to_prob.pxd
@@ -1,4 +1,13 @@
-
+#!/bin/env/python3
+#cython: boundscheck=False
+#cython: cdivision=True
+#cython: initializedcheck=False
+#cython: cdivision_warnings=False
+#cython: wraparound=False
+#cython: binding=False
+#cython: initializedcheck=False
+#cython: nonecheck=False
+#cython: overflowcheck=False
 
 from libc.math cimport exp
 

--- a/src/metawards/_run_model.pyx
+++ b/src/metawards/_run_model.pyx
@@ -133,6 +133,7 @@ def run_model(network: Network,
                                       play_infections=play_infections,
                                       timestep=timestep, files=files,
                                       workspace=workspace,
+                                      nthreads=nthreads,
                                       population=population)
     p = p.stop()
 
@@ -206,6 +207,7 @@ def run_model(network: Network,
                                  timestep=timestep, files=files,
                                  workspace=workspace,
                                  population=population,
+                                 nthreads=nthreads,
                                  profiler=p2)
         p2 = p2.stop()
 

--- a/src/metawards/_run_model.pyx
+++ b/src/metawards/_run_model.pyx
@@ -26,7 +26,6 @@ from ._clear_all_infections import clear_all_infections
 from ._seeding import seed_all_wards, seed_infection_at_node,  \
                       load_additional_seeds, infect_additional_seeds
 from ._extract_data import extract_data
-from ._extract_data_for_graphics import extract_data_for_graphics
 
 
 __all__ = ["run_model"]
@@ -211,12 +210,13 @@ def run_model(network: Network,
                                  profiler=p2)
         p2 = p2.stop()
 
-        p2 = p2.start("extract_data_for_graphics")
-        extract_data_for_graphics(network=network, infections=infections,
-                                  play_infections=play_infections,
-                                  workspace=workspace, FILE=EXPORT,
-                                  profiler=p2)
-        p2 = p2.stop()
+        # Disabling, as Leon says he doesn't need this anymore
+        #p2 = p2.start("extract_data_for_graphics")
+        #extract_data_for_graphics(network=network, infections=infections,
+        #                          play_infections=play_infections,
+        #                          workspace=workspace, FILE=EXPORT,
+        #                          profiler=p2)
+        #p2 = p2.stop()
 
         timestep += 1
 

--- a/src/metawards/_utils.py
+++ b/src/metawards/_utils.py
@@ -27,3 +27,4 @@ from ._iterate_weekend import *
 from ._import_infection import *
 from ._ran_binomial import *
 from ._parallel import *
+from ._assert_sane_network import *


### PR DESCRIPTION
Merging in the parallelisation of extract_data, removal of extract_data_for_graphics (no longer needed) and factorisation out for fixed and play loops.

This now completes in 11.5s on cibod, including the 4.5s of setup (so only 7 s to complete the loop, over 32 threads). This compares to 50s (so 45 s for loop) on 1 thread, and 14.3 s (9 s for loop) with 16 threads.
