### PR TITLE
OS independent test stage

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master, devel, fix-windows-tests]
+    branches: [master, devel]
     tags:
     - '*'
   pull_request:
@@ -54,13 +54,10 @@ jobs:
       - name: Clone MetaWards data
         run: git clone https://github.com/metawards/MetaWardsData
       - name: Run tests
-        run: METAWARDSDATA=./MetaWardsData make test
-        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
-      - name: Run tests (Windows)
-        run: |
-             $env:CYTHONIZE=1; pip install .
-             $env:METAWARDSDATA=".\MetaWardsData"; pytest --cov=metawards --cov-report html:doc/build/html/cov_html tests
-        if: matrix.config.os == 'windows-latest'
+        run: make test
+        env:
+          CYTHONIZE: 1
+          METAWARDSDATA: ./MetaWardsData
       - name: Install packaging requirements
         run: pip install --upgrade setuptools wheel
         if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && contains(github.ref, 'refs/tags/') && github.event_name == 'push'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [master, devel]
+    branches: [master, devel, fix-windows-tests]
     tags:
     - '*'
   pull_request:
@@ -55,9 +55,15 @@ jobs:
         run: git clone https://github.com/metawards/MetaWardsData
       - name: Run tests
         run: METAWARDSDATA=./MetaWardsData make test
+        if: matrix.config.os == 'ubuntu-latest' || matrix.config.os == 'macos-latest'
+      - name: Run tests (Windows)
+        run: |
+             $env:CYTHONIZE=1; pip install .
+             $env:METAWARDSDATA=".\MetaWardsData"; pytest --cov=metawards --cov-report html:doc/build/html/cov_html tests
+        if: matrix.config.os == 'windows-latest'
       - name: Install packaging requirements
         run: pip install --upgrade setuptools wheel
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && contains(github.ref, 'refs/tags/') && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && contains(github.ref, 'refs/tags/') && github.event_name == 'push'
       - name: Make bdist package
         run: |
           pip install --upgrade setuptools wheel
@@ -65,7 +71,7 @@ jobs:
         if: contains(github.ref, 'refs/tags/') && github.event_name == 'push'
       - name: Make sdist package
         run: python setup.py sdist
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && contains(github.ref, 'refs/tags/') && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && contains(github.ref, 'refs/tags/') && github.event_name == 'push'
       - name: Upload sdist/bdist package(s)
         uses: actions/upload-artifact@v1
         with:
@@ -74,23 +80,23 @@ jobs:
         if: contains(github.ref, 'refs/tags/') && github.event_name == 'push'
       - name: Build Docs
         run: python actions/build_docs.py
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push'
       - name: Checkout gh-pages branch
         uses: actions/checkout@v2
         with:
           ref: gh-pages
           path: gh-pages
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push'
       - name: Assemble Website
         run: |
           python actions/assemble_website.py
           python actions/deduplicate_website.py
           python actions/gitupdate_website.py
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push'
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           branch: 'gh-pages'
           directory: 'gh-pages'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        if: matrix.python-version == 3.8 && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
+        if: matrix.python-version == 3.8 && matrix.config.os == 'ubuntu-latest' && github.event_name == 'push'

--- a/src/metawards/utils/_parallel.py
+++ b/src/metawards/utils/_parallel.py
@@ -1,5 +1,6 @@
 
 from array import array
+from sys import platform
 
 __all__ = ["guess_num_threads_and_procs",
            "get_available_num_threads",
@@ -133,6 +134,10 @@ def create_thread_generators(rng, nthreads):
             rngs.append(seed_ran_binomial(seed))
 
     # need to return these as an array so that they are more easily
-    # accessible from the OpenMP loops - rng is a unsigned 64bit integer
+    # accessible from the OpenMP loops - rng is a unsigned 64-bit integer
     # as a uintptr_t - this best corresponds to unsigned long ("L")
-    return array("L", rngs)
+    if platform == "win32":
+        # Use unsigned long long ("Q") on Windows since it has a 32-bit long.
+        return array("Q", rngs)
+    else:
+        return array("L", rngs)


### PR DESCRIPTION
I've used environment variables in the `Run tests` stage so that the `make test` command works on all operating systems. This avoids the need for a custom Windows only test stage to set the `CYTHONIZE` and `METAWARDSDATA` variables in PowerShell, where the syntax is different.

I've also fixed a few outdated references to `matrix.os` in conditional statements. This is now `matrix.config.os`.

Although the tests now run on Windows, several tests are failing with:

```
...
>       return array("L", rngs)
E       OverflowError: Python int too large to convert to C unsigned long
```

Windows uses a 32-bit long so I've added the following code to fix this:

```python
    from sys import platform

    if platform == "win32":
        # Use unsigned long long ("Q") on Windows since it has a 32-bit long.
        return array("Q", rngs)
    else:
        return array("L", rngs)
```