### PR TITLE
Add a Sphinx build script for windows

### DIFF
--- a/doc/winbuild.bat
+++ b/doc/winbuild.bat
@@ -1,0 +1,3 @@
+if not exist "build\html\NUL" mkdir "build\html"
+if not exist "build\doctrees\NUL" mkdir "build\doctrees"
+sphinx-build -b html -d build\doctrees -j8 -v source build\html


### PR DESCRIPTION
Windows users cannot build the documents as-is. A small batch file has been proposed to emulate some of the MakeFile which may not run with Cygwin and / or latest 'make' from GNU tools for Windows.

This will probably need updating later on for consistency across all platforms