### PR TITLE
I've changed the custom functions so that they get the last matching

### DIFF
--- a/src/metawards/extractors/_extract_custom.py
+++ b/src/metawards/extractors/_extract_custom.py
@@ -101,13 +101,17 @@ def build_custom_extractor(custom_function: _Union[str, MetaFunction],
                               f"'{custom_function}'")
 
         if func_name is None:
-            # find the first function that starts with 'extract'
+            # find the last function that starts with 'extract'
             import inspect
+            func = None
             for name, value in inspect.getmembers(module):
                 if name.startswith("extract"):
                     if hasattr(value, "__call__"):
                         # this is a function
-                        return build_custom_extractor(getattr(module, name))
+                        func = value
+
+            if func is not None:
+                return build_custom_extractor(func)
 
             print(f"Could not find any function in the module "
                   f"{custom_function} that has a name that starts "

--- a/src/metawards/iterators/_iterate_custom.py
+++ b/src/metawards/iterators/_iterate_custom.py
@@ -97,13 +97,17 @@ def build_custom_iterator(custom_function: _Union[str, MetaFunction],
                               f"'{custom_function}'")
 
         if func_name is None:
-            # find the first function that starts with 'iterate'
+            # find the last function that starts with 'iterate'
             import inspect
+            func = None
             for name, value in inspect.getmembers(module):
                 if name.startswith("iterate"):
                     if hasattr(value, "__call__"):
                         # this is a function
-                        return build_custom_iterator(getattr(module, name))
+                        func = value
+
+            if func is not None:
+                return build_custom_iterator(func)
 
             print(f"Could not find any function in the module "
                   f"{custom_function} that has a name that starts "

--- a/src/metawards/mixers/_mix_custom.py
+++ b/src/metawards/mixers/_mix_custom.py
@@ -98,13 +98,16 @@ def build_custom_mixer(custom_function: _Union[str, MetaFunction],
                               f"'{custom_function}'")
 
         if func_name is None:
-            # find the first function that starts with 'mix'
+            # find the last function that starts with 'mix'
             import inspect
             for name, value in inspect.getmembers(module):
                 if name.startswith("mix"):
                     if hasattr(value, "__call__"):
                         # this is a function
-                        return build_custom_mixer(getattr(module, name))
+                        func = value
+
+            if func is not None:
+                return build_custom_mixer(func)
 
             print(f"Could not find any function in the module "
                   f"{custom_function} that has a name that starts "

--- a/src/metawards/movers/_move_custom.py
+++ b/src/metawards/movers/_move_custom.py
@@ -98,13 +98,16 @@ def build_custom_mover(custom_function: _Union[str, MetaFunction],
                               f"'{custom_function}'")
 
         if func_name is None:
-            # find the first function that starts with 'move'
+            # find the last function that starts with 'move'
             import inspect
             for name, value in inspect.getmembers(module):
                 if name.startswith("move"):
                     if hasattr(value, "__call__"):
                         # this is a function
-                        return build_custom_mover(getattr(module, name))
+                        func = value
+
+            if func is not None:
+                return build_custom_mover(func)
 
             print(f"Could not find any function in the module "
                   f"{custom_function} that has a name that starts "


### PR DESCRIPTION
function in a file. This should prevent top-level imports being
accidentally selected