### PR TITLE
Solve potentially missing colons in markdown template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment (please complete the following information):**
  - OS: [e.g. Windows 10, Ubuntu 16.04, OS X Catalina)
  - Python: [e.g. 3.7. 3.8, anaconda]
- - Version [e.g. metawards 1.0.0]
+ - Version: [e.g. metawards 1.0.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation-or-tutorial-error.md
+++ b/.github/ISSUE_TEMPLATE/documentation-or-tutorial-error.md
@@ -22,7 +22,7 @@ If applicable, add screenshots to help explain your problem.
 **Environment (if applicable, please complete the following information):**
  - OS: [e.g. Windows 10, Ubuntu 16.04, OS X Catalina)
  - Python: [e.g. 3.7. 3.8, anaconda]
- - Version [e.g. metawards 1.0.0]
+ - Version: [e.g. metawards 1.0.0]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Not a priority, but my OCD has been seeing this for ages, just figured it might as well get done (I was writing some markdown templates for my own project and thought it was time!)

If this is intentional then disregard!